### PR TITLE
add a "mapValues" expression that will do a preg_match

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ List of available functions
 * `reduce(callable $callback, iterable $source) : string`
 * `list(int $length, mixed $value) : iterable`
 * `arrayFilter(array $array, ?callable $callback = null) : array`
+* `mapValues(array $input, iterable $values) : array`
 
 #### Functions that can be used with `reduce`
 

--- a/src/ArrayExpressionLanguageProvider.php
+++ b/src/ArrayExpressionLanguageProvider.php
@@ -26,6 +26,7 @@ class ArrayExpressionLanguageProvider implements ExpressionFunctionProviderInter
             new ExtractData('extractData'),
             new List_('list'),
             new FilterList('filterList'),
+            new MapValues('mapValues'),
         ];
     }
 }

--- a/src/MapValues.php
+++ b/src/MapValues.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\ArrayExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+
+class MapValues extends ExpressionFunction
+{
+    public function __construct($name)
+    {
+        parent::__construct(
+            $name,
+            $this->compile(...)->bindTo($this),
+            $this->evaluate(...)->bindTo($this)
+        );
+    }
+
+    private function compile(string $input, string $values): string
+    {
+        return <<<PHP
+            (function () use(\$input) {
+                \$inputs = {$input};
+                \$patterns = [];
+                \$replacements = [];
+                foreach ({$values} as \$pattern => \$replacement) {
+                    \$patterns[] = '('.\$pattern.')';
+                    \$replacements[] = \$replacement;
+                }
+
+                \$pattern = '/^' . implode('|', \$patterns) . '$/';
+
+                if (is_iterable(\$inputs)) {
+                    foreach (\$inputs as \$key => \$input) {
+                        preg_match(\$pattern, (string) \$input, \$matches);
+
+                        if (empty(\$matches)) {
+                            throw new \Exception(sprintf(
+                            'No replacement found for value "%s". Expected values: %s',
+                             \$input,
+                              implode(', ', array_keys(\$replacements))
+                          ));
+                        }
+
+                        array_shift(\$matches);
+                        \$inputs[\$key] = \$replacements[array_keys(array_filter(\$matches))[0]];
+                    }
+                }
+
+                return \$inputs;
+            })()
+            PHP;
+    }
+
+    private function evaluate(array $context, array $input, array $values)
+    {
+        $inputs = $input;
+        $patterns = [];
+        $replacements = [];
+        foreach ($values as $pattern => $replacement) {
+            $patterns[] = '('.$pattern.')';
+            $replacements[] = $replacement;
+        }
+
+        $pattern = '/^' . implode('|', $patterns) . '$/';
+
+        if (is_iterable($inputs)) {
+            foreach ($inputs as $key => $input) {
+                preg_match($pattern, (string) $input, $matches);
+
+                if (empty($matches)) {
+                    throw new \Exception(sprintf(
+                    'No replacement found for value "%s". Expected values: %s',
+                     $input,
+                      implode(', ', array_keys($replacements))
+                  ));
+                }
+
+                array_shift($matches);
+                $inputs[$key] = $replacements[array_keys(array_filter($matches))[0]];
+            }
+        }
+
+        return $inputs;
+    }
+}


### PR DESCRIPTION
```
expression: >
 mapValues(
 input["product_features"]["a"],
 {
 norm: '3',
 en15102_2007_A1_2001: '1',
 material_pp: '4',
 adhesif: '12',
 ppmat: '13',
 premiummat: '14',
 normandy: '1943'
 }
)
```

```
$output['product_features']['a'] = (function () use($input) {
    $inputs = $input["product_features"]["a"];
    $replacements = ["norm" => 3, "en15102_2007_A1_2001" => 1, "material_pp" => 4, "adhesif" => 12, "ppmat" => 13, "premiummat" => 14, "normandy" => 1943];

    if (is_iterable($inputs)) {
        foreach ($inputs as $key => $input) {
            preg_match('/^((norm)|(en15102_2007_A1_2001)|(material_pp)|(adhesif)|(ppmat)|(premiummat)|(normandy))$/', $input, $matches);

            if (empty($matches)) {
                throw new \Exception(sprintf('No replacement found for value "%s.". Expected values: %s', $input, implode(', ', array_keys($replacements))));
            }

            $inputs[$key] = $replacements[$matches[0]];
        }
    }
    return $inputs;
})();
return $output;
```